### PR TITLE
Program cache key

### DIFF
--- a/build/three.module.js
+++ b/build/three.module.js
@@ -19182,9 +19182,12 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			rendererExtensionShaderTextureLod: isWebGL2 || extensions.has( 'EXT_shader_texture_lod' ),
 			rendererExtensionParallelShaderCompile: extensions.has( 'KHR_parallel_shader_compile' ),
 
-			customProgramCacheKey: material.customProgramCacheKey()
+			customProgramCacheKey: material.customProgramCacheKey(),
+			programCacheKey: '',
 
 		};
+
+		parameters.programCacheKey = material.programCacheKey(parameters);
 
 		return parameters;
 

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -19195,6 +19195,10 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 	function getProgramCacheKey( parameters ) {
 
+		if (parameters.programCacheKey) {
+			return parameters.programCacheKey;
+		}
+
 		const array = [];
 
 		if ( parameters.shaderID ) {

--- a/build/three.module.js
+++ b/build/three.module.js
@@ -7925,6 +7925,22 @@ class Material extends EventDispatcher {
 
 	}
 
+	programCacheKey(parameters) {
+		return '';
+	}
+
+	freeze(freezeFn = parameters => {
+		// this implementation ensures that the typical vertex shader parameters are keyed in the cache
+		return [
+			'freeze',
+			this.uuid,
+			parameters.maxBones,
+			parameters.morphTargetsCount,
+		].join(',');
+	}) {
+		this.programCacheKey = freezeFn;
+	}
+
 	setValues( values ) {
 
 		if ( values === undefined ) return;


### PR DESCRIPTION
Support a new `programCacheKey` method on `Material`, which allows for fine control over recompilation of shaders.