### PR TITLE
Freeze shadow map materials

### DIFF
--- a/build/three.module.js
+++ b/build/three.module.js
@@ -20569,6 +20569,9 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		_maxTextureSize = _capabilities.maxTextureSize;
 
+	_depthMaterial.freeze();
+	_distanceMaterial.freeze();
+
 	const shadowSide = { 0: BackSide, 1: FrontSide, 2: DoubleSide };
 
 	const shadowMaterialVertical = new ShaderMaterial( {


### PR DESCRIPTION
Freezes the default shadow map materials so that they do not get recompiled unless the bones/morphs state changes.

Depends on https://github.com/webaverse/three/pull/5